### PR TITLE
feat(report-generation): implement relevance check

### DIFF
--- a/core/ports/meeting-report-generator.ts
+++ b/core/ports/meeting-report-generator.ts
@@ -1,6 +1,0 @@
-import { Document } from "@/core/domain/document";
-import { MeetingReport } from "@/core/domain/meeting";
-
-export interface MeetingReportGenerator {
-  generate(documents: Document[]): Promise<MeetingReport>;
-}

--- a/core/ports/meeting-report-processor.ts
+++ b/core/ports/meeting-report-processor.ts
@@ -1,0 +1,11 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { Document } from "@/core/domain/document";
+
+export type MeetingReportProcessingResult =
+  | { status: "success"; summary: string; state: any } // state is useful for continuing a workflow later
+  | { status: "irrelevant"; reason: string; state: any }
+  | { status: "error"; reason: string; state: any };
+
+export interface MeetingReportProcessor {
+  process(documents: Document[]): Promise<MeetingReportProcessingResult>;
+}

--- a/core/usecases/generate-meeting-report.ts
+++ b/core/usecases/generate-meeting-report.ts
@@ -1,13 +1,30 @@
 import { Document } from "@/core/domain/document";
-import { MeetingReport } from "@/core/domain/meeting";
-import { MeetingReportGenerator } from "@/core/ports/meeting-report-generator";
+import {
+  MeetingReportProcessingResult,
+  MeetingReportProcessor,
+} from "@/core/ports/meeting-report-processor";
 
 export class GenerateMeetingReportUseCase {
-  constructor(private readonly generator: MeetingReportGenerator) {}
+  constructor(private readonly processor: MeetingReportProcessor) {}
 
-  public async execute(documents: Document[]): Promise<MeetingReport> {
-    console.log("Generating report from pre-validated documents...");
-    const report = await this.generator.generate(documents);
-    return report;
+  public async execute(
+    documents: Document[]
+  ): Promise<MeetingReportProcessingResult> {
+    console.log("Executing meeting report generation logic...");
+
+    if (!documents || documents.length === 0) {
+      console.log("Business rule failed: No documents provided.");
+      return {
+        status: "irrelevant",
+        reason: "No documents were provided to process.",
+        state: null,
+      };
+    }
+
+    const result = await this.processor.process(documents);
+
+    console.log(`Processing finished with status: ${result.status}`);
+
+    return result;
   }
 }

--- a/core/usecases/load-documents.ts
+++ b/core/usecases/load-documents.ts
@@ -36,20 +36,17 @@ export class LoadDocumentsUseCase {
   public async execute(
     initialDocuments: Pick<Document, "id" | "name">[]
   ): Promise<Document[]> {
-    // 1. VALIDATE: Check the number of documents
     if (initialDocuments.length > this.MAX_DOCUMENTS) {
       throw new TooManyDocumentsError(
         `Cannot process more than ${this.MAX_DOCUMENTS} documents. Received ${initialDocuments.length}.`
       );
     }
 
-    // 2. LOAD: Fetch the full content from the source
     const documentIds = initialDocuments.map((doc) => doc.id);
     const loadedDocuments = await this.documentRepository.getContents(
       documentIds
     );
 
-    // 3. VALIDATE: Check token counts and sizes of the loaded content
     const tokensPerDoc = await Promise.all(
       loadedDocuments.map((doc) => this.tokenCounter.countTokens(doc.content))
     );

--- a/infrastructure/di/setupDi.ts
+++ b/infrastructure/di/setupDi.ts
@@ -2,11 +2,12 @@ import { GenerateMeetingReportUseCase } from "@/core/usecases/generate-meeting-r
 import { ConsoleLogger } from "@/infrastructure/adapters/console-logger";
 import { GoogleDocumentRepositoryFactory } from "@/infrastructure/adapters/google-drive-document-repository-factory";
 import { GoogleGeminiTokenCounterFallback } from "@/infrastructure/adapters/google-gemini-token-counter-fallback";
-import { LanggraphMeetingReportGenerator } from "@/infrastructure/adapters/langgraph-meeting-report-generator";
+import { LanggraphMeetingReportProcessor } from "@/infrastructure/adapters/langgraph-meeting-report-processor";
 import { container } from "@/infrastructure/di/container";
 import { DocumentsSummarizerNode } from "@/infrastructure/framework/langchain/documents-summarizer-node";
 import { GoogleAIModelFactory } from "@/infrastructure/framework/langchain/google-ai-model-factory";
 import { MeetingReportAnnotation } from "@/infrastructure/framework/langchain/meeting-report-annotation";
+import { RelevanceCheckNode } from "@/infrastructure/framework/langchain/relevance-check-node";
 import { LoadDocumentsUseCaseFactory } from "@/infrastructure/framework/nextjs/load-documents-factory";
 import { GoogleOAuth2ClientFactory } from "@/infrastructure/google/google-oauth2-client-factory";
 
@@ -24,12 +25,10 @@ export function setupDI() {
   );
 
   container.register(
-    "GoogleAIModelFactory",
+    "AIModelFactory",
     () =>
       new GoogleAIModelFactory({
         apiKey: process.env.CHAT_GOOGLE_GENERATIVE_AI_API_KEY!,
-        defaultModel: "gemini-1.5-flash-latest",
-        defaultTemperature: 0.5,
       })
   );
 
@@ -41,22 +40,32 @@ export function setupDI() {
     ["GoogleOAuth2ClientFactory", "Logger"]
   );
 
-  container.register("SummarizerGoogleAIModel", (container) =>
+  container.register("SummarizerAIModel", (container) =>
     container
-      .resolve("GoogleAIModelFactory")
-      .create({ model: "gemini-2.5-flash-preview-05-20" })
+      .resolve("AIModelFactory")
+      .create({ model: "gemini-2.5-flash-preview-05-20", temperature: 0.4 })
+  );
+
+  container.register("RelevanceCheckAIModel", (container) =>
+    container
+      .resolve("AIModelFactory")
+      .create({ model: "gemini-2.5-flash-preview-04-17", temperature: 0.2 })
   );
 
   container.registerClass("DocumentsSummarizerNode", DocumentsSummarizerNode, [
-    "SummarizerGoogleAIModel",
+    "SummarizerAIModel",
+  ]);
+
+  container.registerClass("RelevanceCheckNode", RelevanceCheckNode, [
+    "RelevanceCheckAIModel",
   ]);
 
   container.registerValue("MeetingReportAnnotation", MeetingReportAnnotation);
 
   container.registerClass(
-    "MeetingReportGenerator",
-    LanggraphMeetingReportGenerator,
-    ["MeetingReportAnnotation", "DocumentsSummarizerNode"]
+    "MeetingReportProcessor",
+    LanggraphMeetingReportProcessor,
+    ["MeetingReportAnnotation", "DocumentsSummarizerNode", "RelevanceCheckNode"]
   );
 
   container.registerClass(
@@ -68,7 +77,7 @@ export function setupDI() {
   container.registerClass(
     "GenerateMeetingReportUseCase",
     GenerateMeetingReportUseCase,
-    ["MeetingReportGenerator"]
+    ["MeetingReportProcessor"]
   );
 
   return container;

--- a/infrastructure/di/types.ts
+++ b/infrastructure/di/types.ts
@@ -1,28 +1,31 @@
 import { Logger } from "@/core/ports/logger";
-import { MeetingReportGenerator } from "@/core/ports/meeting-report-generator";
+import { MeetingReportProcessor } from "@/core/ports/meeting-report-processor";
 import { TokenCounter } from "@/core/ports/token-counter";
 import { GenerateMeetingReportUseCase } from "@/core/usecases/generate-meeting-report";
 import { DocumentRepositoryFactory } from "@/infrastructure/adapters/google-drive-document-repository-factory";
 import { DocumentsSummarizerNode } from "@/infrastructure/framework/langchain/documents-summarizer-node";
 import { GoogleAIModelFactory } from "@/infrastructure/framework/langchain/google-ai-model-factory";
 import { MeetingReportAnnotation } from "@/infrastructure/framework/langchain/meeting-report-annotation";
+import { RelevanceCheckNode } from "@/infrastructure/framework/langchain/relevance-check-node";
 import { LoadDocumentsUseCaseFactory } from "@/infrastructure/framework/nextjs/load-documents-factory";
 import { GoogleOAuth2ClientFactory } from "@/infrastructure/google/google-oauth2-client-factory";
 import { ChatGoogleGenerativeAI } from "@langchain/google-genai";
 
 export interface AppDependencies {
+  DocumentRepositoryFactory: DocumentRepositoryFactory;
   GenerateMeetingReportUseCase: GenerateMeetingReportUseCase;
   Logger: Logger;
-  MeetingReportGenerator: MeetingReportGenerator;
+  MeetingReportProcessor: MeetingReportProcessor;
   TokenCounter: TokenCounter;
 
-  DocumentRepositoryFactory: DocumentRepositoryFactory;
+  AIModelFactory: GoogleAIModelFactory;
   DocumentsSummarizerNode: DocumentsSummarizerNode;
-  GoogleAIModelFactory: GoogleAIModelFactory;
   GoogleOAuth2ClientFactory: GoogleOAuth2ClientFactory;
   LoadDocumentsUseCaseFactory: LoadDocumentsUseCaseFactory;
   MeetingReportAnnotation: typeof MeetingReportAnnotation;
-  SummarizerGoogleAIModel: ChatGoogleGenerativeAI;
+  RelevanceCheckNode: RelevanceCheckNode;
+  RelevanceCheckAIModel: ChatGoogleGenerativeAI;
+  SummarizerAIModel: ChatGoogleGenerativeAI;
 }
 
 export type DependencyToken = keyof AppDependencies;

--- a/infrastructure/framework/langchain/meeting-report-annotation.ts
+++ b/infrastructure/framework/langchain/meeting-report-annotation.ts
@@ -12,6 +12,14 @@ export const MeetingReportAnnotation = Annotation.Root({
     },
     default: () => [],
   }),
+  failureReason: Annotation<string | null>({
+    reducer: (_, updateValue) => updateValue,
+    default: () => null,
+  }),
+  isRelevant: Annotation<boolean | null>({
+    reducer: (_, updateValue) => updateValue,
+    default: () => null,
+  }),
   summary: Annotation<string>({
     reducer: (_, updateValue) => updateValue,
     default: () => "",

--- a/infrastructure/framework/langchain/relevance-check-node.ts
+++ b/infrastructure/framework/langchain/relevance-check-node.ts
@@ -1,0 +1,75 @@
+import { MeetingReportStateAnnotation } from "@/infrastructure/framework/langchain/meeting-report-annotation";
+import { StringOutputParser } from "@langchain/core/output_parsers";
+import {
+  ChatPromptTemplate,
+  HumanMessagePromptTemplate,
+} from "@langchain/core/prompts";
+import { ChatGoogleGenerativeAI } from "@langchain/google-genai";
+
+export class RelevanceCheckNode {
+  private chain;
+
+  constructor(private model: ChatGoogleGenerativeAI) {
+    const prompt = ChatPromptTemplate.fromMessages([
+      HumanMessagePromptTemplate.fromTemplate(
+        `Review the following documents and determine if they contain information relevant to a single meeting, such that a structured meeting report (participants, agenda, discussion points, decisions) could potentially be extracted.
+
+        Consider the document titles and a brief look at their content.
+        Ignore documents that seem completely unrelated to a meeting (e.g., project plans, code files, random notes without meeting context).
+
+        Answer ONLY with the word "YES" if relevant, or "NO" if not relevant. Do not include any other text, punctuation, or explanation.
+
+        Documents:
+        ---
+        {documents}
+        ---
+
+        Answer:`
+      ),
+    ]);
+
+    this.chain = prompt
+      .pipe(this.model.withConfig({ stop: ["."] }))
+      .pipe(new StringOutputParser());
+  }
+
+  public async check(
+    state: MeetingReportStateAnnotation
+  ): Promise<Partial<MeetingReportStateAnnotation>> {
+    console.log("Checking documents relevance...");
+
+    if (!state.documents || state.documents.length === 0) {
+      console.log("No documents found for relevance check.");
+      return { isRelevant: false, failureReason: "No documents provided." };
+    }
+
+    const documentsText = state.documents
+      .map(
+        (doc, index) =>
+          `Document ${index + 1}: ${doc.name}\n${doc.content.substring(
+            0,
+            200
+          )}${doc.content.length > 200 ? "..." : ""}`
+      )
+      .join("\n---\n");
+
+    const relevanceResponse = await this.chain.invoke({
+      documents: documentsText,
+    });
+    const isRelevant = relevanceResponse.trim().toUpperCase() === "YES";
+
+    console.log(
+      "Relevance check result:",
+      relevanceResponse.trim(),
+      "->",
+      isRelevant ? "Relevant" : "Not Relevant"
+    );
+
+    return {
+      isRelevant,
+      failureReason: isRelevant
+        ? undefined
+        : "Documents deemed irrelevant for a meeting report.",
+    };
+  }
+}


### PR DESCRIPTION
This pull request introduces a new "relevance check" step in the meeting report generation workflow.

Key changes include:

- **Refactoring of Meeting Report Generation:**
    - Replaced `MeetingReportGenerator` interface with `MeetingReportProcessor` to better reflect the multi-step processing nature.
    - Updated `GenerateMeetingReportUseCase` to utilize the new `MeetingReportProcessor` and incorporate the relevance check logic.
    - Renamed `LanggraphMeetingReportGenerator` to `LanggraphMeetingReportProcessor` and updated its implementation to integrate the relevance check node.

- **Introduction of Relevance Check:**
    - Added a new `RelevanceCheckNode` in `infrastructure/framework/langchain/relevance-check-node.ts` to determine if provided documents are relevant for generating a meeting report.
    - Modified `MeetingReportAnnotation` to include `isRelevant` and `failureReason` fields for tracking the relevance check outcome.

- **Dependency Injection Updates:**
    - `setupDI.ts` and `types.ts` have been updated to register and inject the new `MeetingReportProcessor` and `RelevanceCheckNode` dependencies.

These changes enhance the robustness of the meeting report generation by pre-screening documents for relevance, preventing unnecessary processing of irrelevant content.